### PR TITLE
#96 - Added timestamp support for console log output.

### DIFF
--- a/bg3-modders-multitool/bg3-modders-multitool/App.config
+++ b/bg3-modders-multitool/bg3-modders-multitool/App.config
@@ -24,6 +24,9 @@
       <setting name="gameDocumentsPath" serializeAs="String">
         <value />
       </setting>
+      <setting name="enableConsoleTimestamp" serializeAs="String">
+        <value>True</value>
+      </setting>
     </bg3_modders_multitool.Properties.Settings>
   </userSettings>
   <entityFramework>

--- a/bg3-modders-multitool/bg3-modders-multitool/Properties/Settings.Designer.cs
+++ b/bg3-modders-multitool/bg3-modders-multitool/Properties/Settings.Designer.cs
@@ -70,5 +70,17 @@ namespace bg3_modders_multitool.Properties {
                 this["gameDocumentsPath"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool enableConsoleTimestamp {
+            get {
+                return ((bool)(this["enableConsoleTimestamp"]));
+            }
+            set {
+                this["enableConsoleTimestamp"] = value;
+            }
+        }
     }
 }

--- a/bg3-modders-multitool/bg3-modders-multitool/Properties/Settings.settings
+++ b/bg3-modders-multitool/bg3-modders-multitool/Properties/Settings.settings
@@ -14,5 +14,8 @@
     <Setting Name="gameDocumentsPath" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="enableConsoleTimestamp" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/bg3-modders-multitool/bg3-modders-multitool/Services/GeneralHelper.cs
+++ b/bg3-modders-multitool/bg3-modders-multitool/Services/GeneralHelper.cs
@@ -21,7 +21,7 @@ namespace bg3_modders_multitool.Services
         public static void WriteToConsole(string text)
         {
             Application.Current.Dispatcher.Invoke(() => {
-                ((MainWindow)Application.Current.MainWindow.DataContext).ConsoleOutput += text;
+                ((MainWindow)Application.Current.MainWindow.DataContext).WriteToConsole(text);
             });
         }
 

--- a/bg3-modders-multitool/bg3-modders-multitool/ViewModels/MainWindow.cs
+++ b/bg3-modders-multitool/bg3-modders-multitool/ViewModels/MainWindow.cs
@@ -99,7 +99,7 @@ namespace bg3_modders_multitool.ViewModels
             if (GuidText != null)
             {
                 Clipboard.SetText(GuidText);
-                ConsoleOutput += $"{type} [{GuidText}] copied to clipboard!\n";
+                WriteToConsole($"{type} [{GuidText}] copied to clipboard!");
             }
         }
         #endregion
@@ -184,12 +184,12 @@ namespace bg3_modders_multitool.ViewModels
                 // Validate the mods folder path.
                 ModsFolderLoaded = Directory.Exists(PathHelper.ModsFolderPath);
                 if(!ModsFolderLoaded)
-                    ConsoleOutput += $"Error: Unable to find the Mods folder at {PathHelper.ModsFolderPath}. Please check your settings.\n";
+                    WriteToConsole($"Error: Unable to find the Mods folder at {PathHelper.ModsFolderPath}. Please check your settings.");
 
                 // Validate the player profiles folder path.
                 ProfilesFolderLoaded = Directory.Exists(PathHelper.PlayerProfilesFolderPath);
                 if (!ProfilesFolderLoaded)
-                    ConsoleOutput += $"Error: Unable to find the PlayerProfiles folder at {PathHelper.PlayerProfilesFolderPath}. Please check your settings.\n";
+                    WriteToConsole($"Error: Unable to find the PlayerProfiles folder at {PathHelper.PlayerProfilesFolderPath}. Please check your settings.");
 
                 ConfigNeeded = ValidateConfigNeeded();
                 OnNotifyPropertyChanged();
@@ -296,6 +296,23 @@ namespace bg3_modders_multitool.ViewModels
         #endregion
 
         #region Auxiliary Methods
+
+        /// <summary>
+        /// Appends a message as a new line to the ConsoleOutput string.
+        /// </summary>
+        /// <param name="message">The message to be appended.</param>
+        public void WriteToConsole(string message)
+        {
+            // Add a timestamp to the message if requested.
+            if (Settings.Default.enableConsoleTimestamp)
+                message = $"[{DateTime.Now.ToLocalTime()}] {message}";
+
+            // Add a newline to the message if it doesn't already have one.
+            if(!message.EndsWith("\n"))
+                message += "\n";
+
+            ConsoleOutput += message;
+        }
 
         /// <summary>
         /// Determines the value of <see cref="Visibility"/> which should have the ConfigNeeded Label


### PR DESCRIPTION
This PR addresses the issue #96 

**Summary**

- Added a new application setting to enable/disable the inclusion of timestamps when writing to console.
- Added a new a new method to centralize manipulation of the MainWindow's ConsoleOutput property, handling timestamp inclusion.
- Updated the GeneralHelper class's WriteToConsole method to use the MainWindow new method.