### PR TITLE
Changes to Decompression

### DIFF
--- a/bg3-modders-multitool/bg3-modders-multitool/Services/FileHelper.cs
+++ b/bg3-modders-multitool/bg3-modders-multitool/Services/FileHelper.cs
@@ -6,6 +6,7 @@ namespace bg3_modders_multitool.Services
     using Alphaleonis.Win32.Filesystem;
     using BrendanGrant.Helpers.FileAssociation;
     using LSLib.LS;
+    using LSLib.LS.Enums;
     using Newtonsoft.Json;
     using System;
     using System.Collections.Generic;
@@ -54,33 +55,44 @@ namespace bg3_modders_multitool.Services
                     File.Move(path, renamedPath);
                     path = renamedPath;
                 }
-                var divine = $" -g \"bg3\" --action \"convert-resource\" --output-format \"{extension}\" --source \"{path}\" --destination \"{newPath}\" -l \"all\"";
-                var process = new Process();
-                var startInfo = new ProcessStartInfo
+                var conversionParams = ResourceConversionParameters.FromGameVersion(Game.BaldursGate3);
+                try
                 {
-                    FileName = Properties.Settings.Default.divineExe,
-                    Arguments = divine,
-                    WindowStyle = ProcessWindowStyle.Hidden,
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
-                };
-                process.StartInfo = startInfo;
-                process.Start();
-                process.WaitForExit();
-                var output = process.StandardOutput.ReadToEnd();
-                var error = process.StandardError.ReadToEnd();
-                if (string.IsNullOrEmpty(newPath))
+                    Resource resource = ResourceUtils.LoadResource(path);
+                    ResourceUtils.SaveResource(resource, newPath, conversionParams);
+                }
+                catch (Exception ex)
                 {
-                    GeneralHelper.WriteToConsole(output);
-                    GeneralHelper.WriteToConsole(error);
+                    GeneralHelper.WriteToConsole($"Failed to convert resource: {ex.Message}");
                 }
 
-                if(output.Contains("Failed to convert resource"))
-                {
-                    GeneralHelper.WriteToConsole($"Failed to convert {file} to .{extension}!\n");
-                }
+                //var divine = $" -g \"bg3\" --action \"convert-resource\" --output-format \"{extension}\" --source \"{path}\" --destination \"{newPath}\" -l \"all\"";
+                //var process = new Process();
+                //var startInfo = new ProcessStartInfo
+                //{
+                //    FileName = Properties.Settings.Default.divineExe,
+                //    Arguments = divine,
+                //    WindowStyle = ProcessWindowStyle.Hidden,
+                //    CreateNoWindow = true,
+                //    UseShellExecute = false,
+                //    RedirectStandardOutput = true,
+                //    RedirectStandardError = true
+                //};
+                //process.StartInfo = startInfo;
+                //process.Start();
+                //process.WaitForExit();
+                //var output = process.StandardOutput.ReadToEnd();
+                //var error = process.StandardError.ReadToEnd();
+                //if (string.IsNullOrEmpty(newPath))
+                //{
+                //    //    GeneralHelper.WriteToConsole(output);
+                //    GeneralHelper.WriteToConsole(error);
+                //}
+
+                //if (output.Contains("Failed to convert resource"))
+                //{
+                //    GeneralHelper.WriteToConsole($"Failed to convert {file} to .{extension}!\n");
+                //}
 
                 if (MustRenameLsxResources.Contains(originalExtension))
                 {

--- a/bg3-modders-multitool/bg3-modders-multitool/Services/PakUnpackHelper.cs
+++ b/bg3-modders-multitool/bg3-modders-multitool/Services/PakUnpackHelper.cs
@@ -5,6 +5,7 @@ namespace bg3_modders_multitool.Services
 {
     using Alphaleonis.Win32.Filesystem;
     using bg3_modders_multitool.ViewModels;
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -124,6 +125,8 @@ namespace bg3_modders_multitool.Services
                 GeneralHelper.WriteToConsole($"Retrived file list. Starting decompression; this could take awhile.\n");
                 var defaultPath = @"\\?\" + FileHelper.GetPath("");
                 var convertFiles = new List<string>();
+                Stopwatch stopWatch = new Stopwatch();
+                stopWatch.Start();
                 Parallel.ForEach(fileList, file => {
                     var extension = Path.GetExtension(file);
                     if (!string.IsNullOrEmpty(extension))
@@ -147,8 +150,12 @@ namespace bg3_modders_multitool.Services
                         
                     }
                 });
+                stopWatch.Stop();
+                TimeSpan ts = stopWatch.Elapsed;
+                string elapsedTime = String.Format("{0:00}:{1:00}:{2:00}.{3:00}", ts.Hours, ts.Minutes, ts.Seconds, ts.Milliseconds / 10);
+
                 fileList.Clear();
-                GeneralHelper.WriteToConsole($"Decompression complete.\n");
+                GeneralHelper.WriteToConsole($"Decompression completed in {elapsedTime}.\n");
                 return convertFiles;
             });
         }

--- a/bg3-modders-multitool/bg3-modders-multitool/Views/MainWindow.xaml.cs
+++ b/bg3-modders-multitool/bg3-modders-multitool/Views/MainWindow.xaml.cs
@@ -115,13 +115,13 @@ namespace bg3_modders_multitool.Views
             new GameObjectWindow().Show();
         }
 
-        private async void Decompress_Click(object sender, RoutedEventArgs e)
+        private void Decompress_Click(object sender, RoutedEventArgs e)
         {
             var vm = DataContext as ViewModels.MainWindow;
             if(vm.NotDecompressing)
             {
                 vm.NotDecompressing = false;
-                await PakUnpackHelper.DecompressAllConvertableFiles().ContinueWith(delegate {
+                PakUnpackHelper.DecompressAllConvertableFiles().ContinueWith(delegate {
                     Application.Current.Dispatcher.Invoke(() => {
                         vm.NotDecompressing = true;
                     });


### PR DESCRIPTION
Hello,
this pull request was created to merge the following changes:

5e11e903a9318687e1fa593dd1ba93f9ea84e8f1 : 
The await in Decompress_Click was blocking the main ui-thread. Making the application window non responsiv

0f19cb1fbae340a16f443149be2c7b69c38c0b5c : 
Changed the .lsf to .lsx converter to using the LSLib directly. The method was taking longer to instantiate the console process and the divine.exe process then decompressing the files. 
Runtime for Gustav and Shared with divine: 00:23:53.46
Runtime for Gustav and Shared with LSLib: 00:04:40.86

The original code is commented out, so feel free to delete it if the changes are approved.

7e7db022ad16c4fad328da1fb9acfb60f7a4cb22:
Added a Stopwatch to display the running time of DecompressAllConvertableFiles

I hope that you can incorparate this pull request, so others can benefit from the changes.

If you have questions and/or comments please contact me. 
Thank you for your time!

FinaudMod